### PR TITLE
Signed contributors.txt

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -127,3 +127,4 @@ YYYY/MM/DD, github id, Full name, email
 2016/12/01, samtatasurya, Samuel Tatasurya, xemradiant@gmail.com
 2016/12/03, redxdev, Samuel Bloomberg, sam@redxdev.com
 2016/12/11, Gaulouis, Gaulouis, gaulouis.com@gmail.com
+2017/06/11, erikbra, Erik A. Brandstadmoen, erik@brandstadmoen.net


### PR DESCRIPTION
<!--
Thank you for proposing a contribution to the ANTLR project. In order to accept changes from the outside world, all contributors must "sign" the  [contributors.txt](https://github.com/antlr/antlr4/blob/master/contributors.txt) contributors certificate of origin. It's an unfortunate reality of today's fuzzy and bizarre world of open-source ownership.

Make sure you are already in the contributors.txt file or add a commit to this pull request with the appropriate change. Thanks!
-->